### PR TITLE
fix openai rosdep

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -13,7 +13,7 @@
 
   <author email="tomoya.fujita825@gmail.com">Tomoya Fujita</author>
 
-  <exec_depend>openai</exec_depend>
+  <exec_depend>python3-openai-pip</exec_depend>
   <exec_depend>ros2cli</exec_depend>
 
   <test_depend>ament_copyright</test_depend>


### PR DESCRIPTION
`openai` isn't a valid rosdep, it has however been registered as `python3-openai-pip` in [rosdistro](https://github.com/ros/rosdistro/blob/5d214598898013d4dcf7155a62c6564515108db6/rosdep/python.yaml#L7331).