### PR TITLE
Enable the use of self-hosted LLMs

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -13,6 +13,7 @@
 
   <author email="tomoya.fujita825@gmail.com">Tomoya Fujita</author>
 
+  <exec_depend>curl</exec_depend>
   <exec_depend>python3-openai-pip</exec_depend>
   <exec_depend>ros2cli</exec_depend>
 

--- a/ros2ai/api/__init__.py
+++ b/ros2ai/api/__init__.py
@@ -22,11 +22,11 @@ import ros2ai.api.constants as constants
 def add_global_arguments(parser):
         # add global arguments
     parser.add_argument(
-        '-m', '--model', metavar='<model>', type=str, default=constants.ROS_OPENAI_DEFAULT_MODEL,
+        '-m', '--model', metavar='<model>', type=str, default=None,
         help=f'Set OpenAI API model (default %(default)s) or '
             f'use {constants.ROS_OPENAI_MODEL_NAME_ENV_VAR} environment variable. (argument prevails)')
     parser.add_argument(
-        '-u', '--url', metavar='<url>', type=str, default=constants.ROS_OPENAI_DEFAULT_ENDPOINT,
+        '-u', '--url', metavar='<url>', type=str, default=None,
         help='Set OpenAI API endpoint URL (default %(default)s) or '
             f'use {constants.ROS_OPENAI_ENDPOINT_ENV_VAR} environment variable. (argument prevails)')
     parser.add_argument(

--- a/ros2ai/api/config.py
+++ b/ros2ai/api/config.py
@@ -28,13 +28,8 @@ def get_api_key() -> str:
     :return: string of OpenAI API Key.
     :raises: if OPENAI_API_KEY is not set.
     """
-    key_name = os.environ.get(constants.ROS_OPENAI_API_KEY_ENV_VAR)
-    if not key_name:
-        raise EnvironmentError(
-            f"'{constants.ROS_OPENAI_API_KEY_ENV_VAR}' environment variable is not set'"
-        )
-    else:
-        return key_name
+    key_name = os.environ.get(constants.ROS_OPENAI_API_KEY_ENV_VAR, "")
+    return key_name
 
 def get_ai_model() -> str:
     """

--- a/ros2ai/api/config.py
+++ b/ros2ai/api/config.py
@@ -73,6 +73,9 @@ def get_temperature() -> float:
     else:
         return float(temperature)
 
+def get_role_system(default_role_system: str = None) -> str:
+    return os.environ.get(constants.ROLE_SYSTEM_ENV_VAR, default_role_system)
+
 class OpenAiConfig:
     """
     Collect all OpenAI API related configuration from user setting as key-value pair.

--- a/ros2ai/api/config.py
+++ b/ros2ai/api/config.py
@@ -28,7 +28,7 @@ def get_api_key() -> str:
     :return: string of OpenAI API Key.
     :raises: if OPENAI_API_KEY is not set.
     """
-    key_name = os.environ.get(constants.ROS_OPENAI_API_KEY_ENV_VAR, "")
+    key_name = os.environ.get(constants.ROS_OPENAI_API_KEY_ENV_VAR, "None")
     return key_name
 
 def get_ai_model() -> str:

--- a/ros2ai/api/config.py
+++ b/ros2ai/api/config.py
@@ -122,7 +122,8 @@ class OpenAiConfig:
     def is_api_key_valid(self):
         # Validate api key, model and endpoint to post the API
         client = OpenAI(
-            api_key=self.get_value('api_key')
+            api_key=self.get_value('api_key'),
+            base_url=self.get_value('api_endpoint')
         )
         try:
             completion = client.chat.completions.create(

--- a/ros2ai/api/config.py
+++ b/ros2ai/api/config.py
@@ -85,12 +85,12 @@ class OpenAiConfig:
 
         # ai model is optional, command line argument prevails
         self.config_pair['api_model'] = get_ai_model()
-        if args.model != constants.ROS_OPENAI_DEFAULT_MODEL:
+        if args.model and args.model != self.config_pair['api_model']:
             self.config_pair['api_model'] = args.model
 
         # api endpoint is optional, command line argument prevails
         self.config_pair['api_endpoint'] = get_endpoint_url()
-        if args.url != constants.ROS_OPENAI_DEFAULT_MODEL:
+        if args.url and args.url != self.config_pair['api_endpoint']:
             self.config_pair['api_endpoint'] = args.url
 
         # api token is optional, only available via command line argument

--- a/ros2ai/api/constants.py
+++ b/ros2ai/api/constants.py
@@ -32,6 +32,7 @@ ROLE_SYSTEM_QUERY_DEFAULT = \
 ROLE_SYSTEM_EXEC_DEFAULT = \
     'You are a Robot Operating System 2 (as known as ROS2) {} distribution command line executor, ' \
     'provides executable command string only without any comments or code blocks.'
+ROLE_SYSTEM_ENV_VAR = 'OPENAI_ROLE_SYSTEM'
 
 # Temperature controls the consistency for behavior. (range 0.0 - 2.0)
 # The lower the temperature is, the more deterministic behavior that OpenAI does.

--- a/ros2ai/api/openai.py
+++ b/ros2ai/api/openai.py
@@ -26,7 +26,8 @@ class ChatCompletionClient(OpenAiConfig):
         super().__init__(args)
 
         self.client_ = OpenAI(
-            api_key=self.get_value('api_key')
+            api_key=self.get_value('api_key'),
+            base_url=self.get_value('api_endpoint')
         )
         self.completion_ = None
         self.stream_ = True

--- a/ros2ai/verb/exec.py
+++ b/ros2ai/verb/exec.py
@@ -36,6 +36,10 @@ class ExecVerb(VerbExtension):
             '--debug',
             action='store_true',
             help='Prints detailed information and behavior of OpenAI (debug use only)')
+        parser.add_argument(
+            '--dry-run',
+            action='store_true',
+            help='Prints the command instead of executing it.')
 
     def main(self, *, args):
         request = ''
@@ -60,4 +64,7 @@ class ExecVerb(VerbExtension):
             client.print_all()
         command_str = truncate_before_substring(
             original = client.get_result(), substring = 'ros2')
-        run_executable(command = command_str)
+        if not args.dry_run:
+            run_executable(command = command_str)
+        else:
+            print(f"Command: '{command_str}'")

--- a/ros2ai/verb/status.py
+++ b/ros2ai/verb/status.py
@@ -45,6 +45,12 @@ class StatusVerb(VerbExtension):
         # try to call OpenAI API with user configured setting
         is_valid = openai_config.is_api_key_valid()
 
+        if is_valid:
+            print("[SUCCESS] Valid OpenAI API key.")
+        else:
+            print("[FAILURE] Invalid OpenAI API key.")
+            return 1
+
         # try to list the all models via user configured api key
         headers = {"Authorization": "Bearer " + openai_config.get_value('api_key')}
         can_get_models, model_list = curl_get_request(
@@ -52,10 +58,10 @@ class StatusVerb(VerbExtension):
             headers
         )
 
-        if is_valid and can_get_models:
-            print("[SUCCESS] Valid OpenAI API key.")
+        if can_get_models:
+            print("[SUCCESS] Retrieved list of models.")
         else:
-            print("[FAILURE] Invalid OpenAI API key.")
+            print("[FAILURE] Could not retrieved list of models.")
             return 1
 
         if (args.list is True):

--- a/ros2ai/verb/status.py
+++ b/ros2ai/verb/status.py
@@ -45,7 +45,7 @@ class StatusVerb(VerbExtension):
         # try to call OpenAI API with user configured setting
         is_valid = openai_config.is_api_key_valid()
 
-        if is_valid:
+        if is_valid and args.verbose:
             print("[SUCCESS] Valid OpenAI API key.")
         else:
             print("[FAILURE] Invalid OpenAI API key.")
@@ -58,7 +58,7 @@ class StatusVerb(VerbExtension):
             headers
         )
 
-        if can_get_models:
+        if can_get_models and args.verbose:
             print("[SUCCESS] Retrieved list of models.")
         else:
             print("[FAILURE] Could not retrieved list of models.")

--- a/ros2ai/verb/status.py
+++ b/ros2ai/verb/status.py
@@ -45,8 +45,9 @@ class StatusVerb(VerbExtension):
         # try to call OpenAI API with user configured setting
         is_valid = openai_config.is_api_key_valid()
 
-        if is_valid and args.verbose:
-            print("[SUCCESS] Valid OpenAI API key.")
+        if is_valid:
+            if args.verbose:
+                print("[SUCCESS] Valid OpenAI API key.")
         else:
             print("[FAILURE] Invalid OpenAI API key.")
             return 1
@@ -58,8 +59,9 @@ class StatusVerb(VerbExtension):
             headers
         )
 
-        if can_get_models and args.verbose:
-            print("[SUCCESS] Retrieved list of models.")
+        if can_get_models:
+            if args.verbose:
+                print("[SUCCESS] Retrieved list of models.")
         else:
             print("[FAILURE] Could not retrieved list of models.")
             return 1

--- a/ros2ai/verb/status.py
+++ b/ros2ai/verb/status.py
@@ -54,7 +54,7 @@ class StatusVerb(VerbExtension):
         # try to list the all models via user configured api key
         headers = {"Authorization": "Bearer " + openai_config.get_value('api_key')}
         can_get_models, model_list = curl_get_request(
-            "https://api.openai.com/v1/models",
+            openai_config.get_value('api_endpoint') + "/models",
             headers
         )
 

--- a/scripts/verification.sh
+++ b/scripts/verification.sh
@@ -62,7 +62,7 @@ function verify_ros2ai() {
     echo "[${FUNCNAME[0]}]: verifying ros2ai."
     # execute all commands in the list
     for command in "${command_list[@]}"; do
-        #echo "----- $command"
+        echo "----- $command"
         eval $command
     done
     echo "----- all ros2ai commands return successfully!!! -----"


### PR DESCRIPTION
This PR introduces several fixes and features that enable the use of other, open-ai api compatible, LLMs such as those served by the [Ollama](https://ollama.com/) framework.

Most notably:

- Make use of the api endpoint
- Add a `--dry-run` option to `exec` that prints the answer without executing it
- Enable setting up the system prompts through env var & cli arg