### PR TITLE
Correct the name of a dependent package

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -16,7 +16,7 @@
   <exec_depend>curl</exec_depend>
   <exec_depend>python3-openai-pip</exec_depend>
   <exec_depend>python3-ollama-pip</exec_depend>
-  <exec_depend>python3-validators-pip</exec_depend>
+  <exec_depend>python3-validators</exec_depend>
   <exec_depend>ros2cli</exec_depend>
 
   <test_depend>ament_copyright</test_depend>


### PR DESCRIPTION
This issue was discovered when `bloom-release` execution failed.    

According to https://github.com/ros/rosdistro/blob/master/rosdep/python.yaml, the correct name should be `python3-validators`.

