### PR TITLE
remove Ollama dependency.

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -15,7 +15,6 @@
 
   <exec_depend>curl</exec_depend>
   <exec_depend>python3-openai-pip</exec_depend>
-  <exec_depend>python3-ollama-pip</exec_depend>
   <exec_depend>python3-validators</exec_depend>
   <exec_depend>ros2cli</exec_depend>
 


### PR DESCRIPTION
Since ros2ai uses the OpenAI API interface and doesn't directly depend on ollama's interfaces, this dependency can be removed.