### PR TITLE
remove deprecated warnings from newer setuptools.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -24,14 +24,13 @@ setup(
     classifiers=[
         'Environment :: Console',
         'Intended Audience :: Developers',
-        'License :: OSI Approved :: Apache Software License',
         'Programming Language :: Python',
     ],
     description='The OpenAI command for ROS 2 command line tools.',
     long_description="""\
         The package provides the AI command for the ROS 2 command line tools.""",
-    license='Apache License, Version 2.0',
-    tests_require=['pytest'],
+    license='Apache-2.0',
+    extras_require={'test': ['pytest']},
     entry_points={
         'ros2cli.command': [
             'ai = ros2ai.command.ai:AiCommand',


### PR DESCRIPTION
remove the following warnings.

```concole
root@tomoyafujita-ZBOX-EU275070C-EU27507TC:~/docker_ws/ros2_colcon# colcon build --symlink-install --packages-select ros2ai
Starting >>> ros2ai
/usr/lib/python3/dist-packages/setuptools/_distutils/dist.py:289: UserWarning: Unknown distribution option: 'tests_require'
  warnings.warn(msg)
/usr/lib/python3/dist-packages/setuptools/dist.py:759: SetuptoolsDeprecationWarning: License classifiers are deprecated.
!!

        ********************************************************************************
        Please consider removing the following classifiers in favor of a SPDX license expression:

        License :: OSI Approved :: Apache Software License

        See https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#license for details.
        ********************************************************************************

!!
  self._finalize_license_expression()
--- stderr: ros2ai
/usr/lib/python3/dist-packages/setuptools/_distutils/dist.py:289: UserWarning: Unknown distribution option: 'tests_require'
  warnings.warn(msg)
/usr/lib/python3/dist-packages/setuptools/dist.py:759: SetuptoolsDeprecationWarning: License classifiers are deprecated.
!!

        ********************************************************************************
        Please consider removing the following classifiers in favor of a SPDX license expression:

        License :: OSI Approved :: Apache Software License

        See https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#license for details.
        ********************************************************************************

!!
  self._finalize_license_expression()
---
Finished <<< ros2ai [1.57s]

Summary: 1 package finished [2.43s]
  1 package had stderr output: ros2ai


  why am i seeing those warnings?
```